### PR TITLE
PrettyPrint should be extensible

### DIFF
--- a/source/Octopus.Diagnostics/ICustomPrettyPrintHandler.cs
+++ b/source/Octopus.Diagnostics/ICustomPrettyPrintHandler.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Text;
+
+namespace Octopus.Diagnostics
+{
+    /// <summary>
+    /// Do not implement this interface directly, use the generics based one.
+    /// </summary>
+    public interface ICustomPrettyPrintHandler
+    {
+        /// <summary>
+        /// Custom handler for PrettyPrinting a type of exception
+        /// </summary>
+        /// <param name="sb">StringBuilder for the "pretty" output</param>
+        /// <param name="ex">The exception instance</param>
+        /// <returns>True if the processing should continue on to processing stack trace or inner exceptions</returns>
+        bool Handle(StringBuilder sb, Exception ex);
+    }
+
+    public interface ICustomPrettyPrintHandler<in TException> : ICustomPrettyPrintHandler
+    {
+    }
+}

--- a/source/Octopus.Diagnostics/ICustomPrettyPrintHandler.cs
+++ b/source/Octopus.Diagnostics/ICustomPrettyPrintHandler.cs
@@ -4,9 +4,11 @@ using System.Text;
 namespace Octopus.Diagnostics
 {
     /// <summary>
-    /// Do not implement this interface directly, use the generics based one.
+    /// BEWARE your custom exception types must be public or the dynamic dispatch we do in here will not work correctly!!!
     /// </summary>
-    public interface ICustomPrettyPrintHandler
+    /// <typeparam name="TException"></typeparam>
+    public interface ICustomPrettyPrintHandler<in TException>
+        where TException : Exception
     {
         /// <summary>
         /// Custom handler for PrettyPrinting a type of exception
@@ -14,10 +16,6 @@ namespace Octopus.Diagnostics
         /// <param name="sb">StringBuilder for the "pretty" output</param>
         /// <param name="ex">The exception instance</param>
         /// <returns>True if the processing should continue on to processing stack trace or inner exceptions</returns>
-        bool Handle(StringBuilder sb, Exception ex);
-    }
-
-    public interface ICustomPrettyPrintHandler<in TException> : ICustomPrettyPrintHandler
-    {
+        bool Handle(StringBuilder sb, TException ex);
     }
 }

--- a/source/Octopus.Diagnostics/Octopus.Diagnostics.csproj
+++ b/source/Octopus.Diagnostics/Octopus.Diagnostics.csproj
@@ -23,4 +23,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" Condition="'$(TargetFramework)' == 'net452'" />
+  </ItemGroup>
 </Project>

--- a/source/Octopus.Diagnostics/Octopus.Diagnostics.csproj
+++ b/source/Octopus.Diagnostics/Octopus.Diagnostics.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>

--- a/source/Octopus.Diagnostics/PrettyPrint.cs
+++ b/source/Octopus.Diagnostics/PrettyPrint.cs
@@ -22,7 +22,7 @@ namespace Octopus.Diagnostics
 
         public static void AddCustomExceptionHandler<TException>(HandleExceptionOfType handler)
         {
-            CustomExceptionTypeHandlers.Add(typeof(TException), handler);
+            CustomExceptionTypeHandlers[typeof(TException)] = handler;
         }
 
         public static string PrettyPrint(this Exception ex, bool printStackTrace = true)

--- a/source/Octopus.Diagnostics/TypeExtensionMethods.cs
+++ b/source/Octopus.Diagnostics/TypeExtensionMethods.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Octopus.Diagnostics
+{
+    static class TypeExtensionMethods
+    {
+        public static bool IsClosedGenericOfType(this Type typeToCheck, Type openGenericType)
+        {
+            if (!openGenericType.IsGenericType)
+                return false;
+            var closedGenericOfExceptionTypes = typeToCheck.ClosedGenericOfExceptionTypes(openGenericType);
+            return closedGenericOfExceptionTypes.Length > 0;
+        }
+
+        public static Type[] ClosedGenericOfExceptionTypes(this Type typeToCheck, Type openGenericType)
+        {
+            return typeToCheck.GetCompleteHierarchy()
+                .Where(t => t.IsGenericType && t.GetTypeInfo().GetGenericTypeDefinition() == openGenericType)
+                .Select(t => t.GetGenericArguments().First())
+                .ToArray();
+        }
+
+        static IEnumerable<Type> GetCompleteHierarchy(this Type type)
+        {
+            yield return type;
+
+            var interfaceTypes = type.GetInterfaces()
+                .SelectMany(i => i.GetCompleteHierarchy())
+                .Distinct()
+                .ToArray();
+            foreach (var t in interfaceTypes) yield return t;
+
+            var baseTypes = type.BaseType?.GetCompleteHierarchy() ?? new Type[0];
+            foreach (var t in baseTypes) yield return t;
+        }
+    }
+}

--- a/source/Tests/PrettyPrintFixture.AggregateExceptionWithStackTrace.approved.core.txt
+++ b/source/Tests/PrettyPrintFixture.AggregateExceptionWithStackTrace.approved.core.txt
@@ -2,21 +2,21 @@ Aggregate Exception
 System.AggregateException
    at System.Threading.Tasks.Task.WaitAllCore(Task[] tasks, Int32 millisecondsTimeout, CancellationToken cancellationToken)
    at System.Threading.Tasks.Task.WaitAll(Task[] tasks)
-   at Tests.PrettyPrintFixture.<AggregateExceptionWithStackTrace><compiler_generated>() in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.CaptureException(Action action, Boolean stackTrace) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.<AggregateExceptionWithStackTrace><compiler_generated>() in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.CaptureException(Action action, Boolean stackTrace) in PrettyPrintFixture.cs:line <line_number>
 
 --Inner Exception 1--
 Attempted to divide by zero.
 System.DivideByZeroException
-   at Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync(Int32 n) in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync(Int32 n) in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync(Int32 n) in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync(Int32 n) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync(Int32 n) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync(Int32 n) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync(Int32 n) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync(Int32 n) in PrettyPrintFixture.cs:line <line_number>
 
 --Inner Exception 2--
 Attempted to divide by zero.
 System.DivideByZeroException
-   at Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync(Int32 n) in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync(Int32 n) in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync(Int32 n) in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync(Int32 n) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync(Int32 n) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync(Int32 n) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync(Int32 n) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync(Int32 n) in PrettyPrintFixture.cs:line <line_number>

--- a/source/Tests/PrettyPrintFixture.AggregateExceptionWithStackTrace.approved.netfx.txt
+++ b/source/Tests/PrettyPrintFixture.AggregateExceptionWithStackTrace.approved.netfx.txt
@@ -1,21 +1,21 @@
 Aggregate Exception
 System.AggregateException
    at System.Threading.Tasks.Task.WaitAll(Task[] tasks, Int32 millisecondsTimeout, CancellationToken cancellationToken)
-   at Tests.PrettyPrintFixture.<AggregateExceptionWithStackTrace><compiler_generated>() in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.CaptureException(Action action, Boolean stackTrace) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.<AggregateExceptionWithStackTrace><compiler_generated>() in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.CaptureException(Action action, Boolean stackTrace) in PrettyPrintFixture.cs:line <line_number>
 
 --Inner Exception 1--
 Attempted to divide by zero.
 System.DivideByZeroException
-   at Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync in PrettyPrintFixture.cs:line <line_number>
 
 --Inner Exception 2--
 Attempted to divide by zero.
 System.DivideByZeroException
-   at Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowDivideByZeroExceptionAsync in PrettyPrintFixture.cs:line <line_number>

--- a/source/Tests/PrettyPrintFixture.InnerExceptionsWithStackTrace.approved.core.txt
+++ b/source/Tests/PrettyPrintFixture.InnerExceptionsWithStackTrace.approved.core.txt
@@ -1,23 +1,23 @@
 Exception Level 3
 System.Exception
-   at Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.CallThrowInnerException() in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.CaptureException(Action action, Boolean stackTrace) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.CallThrowInnerException() in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.CaptureException(Action action, Boolean stackTrace) in PrettyPrintFixture.cs:line <line_number>
 
 --Inner Exception--
 Exception Level 2
 System.Exception
-   at Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
 
 --Inner Exception--
 Exception Level 1
 System.Exception
-   at Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
 
 --Inner Exception--
 Innermost
 System.Exception
-   at Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>

--- a/source/Tests/PrettyPrintFixture.InnerExceptionsWithStackTrace.approved.netfx.txt
+++ b/source/Tests/PrettyPrintFixture.InnerExceptionsWithStackTrace.approved.netfx.txt
@@ -1,23 +1,23 @@
 Exception Level 3
 System.Exception
-   at Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.CallThrowInnerException() in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.CaptureException(Action action, Boolean stackTrace) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.CallThrowInnerException() in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.CaptureException(Action action, Boolean stackTrace) in PrettyPrintFixture.cs:line <line_number>
 
 --Inner Exception--
 Exception Level 2
 System.Exception
-   at Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
 
 --Inner Exception--
 Exception Level 1
 System.Exception
-   at Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
 
 --Inner Exception--
 Innermost
 System.Exception
-   at Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
-   at Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>
+   at Octopus.Diagnostics.Tests.PrettyPrintFixture.ThrowInnerException(Int32 n) in PrettyPrintFixture.cs:line <line_number>

--- a/source/Tests/PrettyPrintFixture.cs
+++ b/source/Tests/PrettyPrintFixture.cs
@@ -22,6 +22,22 @@ namespace Tests
         private static readonly Configuration PlatformSpecificConfig = Config.UsingExtension("netfx.txt");
 #endif
 
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            ExceptionExtensions.AddCustomExceptionHandler<SqlException>((sb, ex) =>
+            {
+                var number = ((SqlException)ex).Number;
+                sb.AppendLine($"SQL Error {number} - {ex.Message}");
+                return true;
+            });
+            ExceptionExtensions.AddCustomExceptionHandler<ControlledFailureException>((sb, ex) =>
+            {
+                sb.AppendLine(ex.Message);
+                return false;
+            });
+        }
+
         [Test]
         public void InnerExceptionsWithStackTrace()
         {

--- a/source/Tests/PrettyPrintFixture.cs
+++ b/source/Tests/PrettyPrintFixture.cs
@@ -7,22 +7,21 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Assent;
 using NUnit.Framework;
-using Octopus.Diagnostics;
 
-namespace Tests
+namespace Octopus.Diagnostics.Tests
 {
     class SqlPrettyPrintHandler : ICustomPrettyPrintHandler<SqlException>
     {
-        public bool Handle(StringBuilder sb, Exception ex)
+        public bool Handle(StringBuilder sb, SqlException ex)
         {
-            var number = ((SqlException)ex).Number;
+            var number = ex.Number;
             sb.AppendLine($"SQL Error {number} - {ex.Message}");
             return true;
         }
     }
     class ControlledFailureExceptionPrettyPrintHandler : ICustomPrettyPrintHandler<ControlledFailureException>
     {
-        public bool Handle(StringBuilder sb, Exception ex)
+        public bool Handle(StringBuilder sb, ControlledFailureException ex)
         {
             sb.AppendLine(ex.Message);
             return false;
@@ -191,7 +190,7 @@ namespace Tests
         }
     }
 
-    class ControlledFailureException : Exception
+    public class ControlledFailureException : Exception
     {
         public ControlledFailureException() : base("The deployment failed")
         {

--- a/source/Tests/Tests.csproj
+++ b/source/Tests/Tests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyName>Tests</AssemblyName>
-    <RootNamespace>Tests</RootNamespace>
+    <AssemblyName>Octopus.Diagnostics.Tests</AssemblyName>
+    <RootNamespace>Octopus.Diagnostics.Tests</RootNamespace>
     <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
The type checking in here looked like it was going to work, but server ended up with some exceptions that inherit from ControlledFailureException, and except them to be treated the same way here.

This change introduces a way for consumers to add custom handlers for exception types. The delegate returns a bool because some of the handlers, like ControllerFailureException, will want to return false and stop the stack trace and inner exception handling from running.