### PR TITLE
Patch SqlClient vulnerability

### DIFF
--- a/source/Tests/Tests.csproj
+++ b/source/Tests/Tests.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.22" />
     <PackageReference Include="Assent" Version="1.6.1" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />


### PR DESCRIPTION
Microsoft disclosed a [moderate vulnerability](https://github.com/advisories/GHSA-8g2p-5pqh-5jmc) on their SqlClient libraries affecting a few versions.

This PR updates such library to a patched version.

https://octopusdeploy.slack.com/archives/C04AD1H7LLC/p1668387022805969